### PR TITLE
Add from_json method to classes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,13 @@ docs = [
     "mkdocs-material",
     "mkdocs-jupyter",
 ]
-dev = ["jupyter[notebook]>=1.1.1", "jupytext>=1.16.4", "ruff", "pre-commit"]
+dev = [
+    "jupyter[notebook]>=1.1.1",
+    "jupytext>=1.16.4",
+    "ruff",
+    "pre-commit",
+    "pytest>=8.3.3",
+]
 
 [tool.uv]
 default-groups = ["docs", "dev"]

--- a/src/ome_zarr_models/v04/image.py
+++ b/src/ome_zarr_models/v04/image.py
@@ -6,17 +6,17 @@ from typing import Any, Literal, Self
 AxisType = Literal["time", "space", "channel"]
 
 
-class ToFromJSON(ABC):
+class JSONable(ABC):
     """A class that can serialise to and from JSON."""
 
     @classmethod
     @abstractmethod
-    def _from_json(cls, json: dict) -> Self: ...
+    def _from_json(cls, json_: dict) -> Self: ...
 
 
 # TODO: decide if slots is future-proof w.r.t. dynamic data like OMERO
 @dataclass(frozen=True, slots=True, kw_only=True)
-class Axis(ToFromJSON):
+class Axis(JSONable):
     """
     A single axis.
 
@@ -37,15 +37,15 @@ class Axis(ToFromJSON):
     unit: str | None = None
 
     @classmethod
-    def _from_json(cls, json: dict) -> Self:
-        name = json["name"]
-        type_ = json.get("type", None)
-        unit = json.get("unit", None)
+    def _from_json(cls, json_: dict) -> Self:
+        name = json_["name"]
+        type_ = json_.get("type", None)
+        unit = json_.get("unit", None)
         return cls(name=name, type=type_, unit=unit)
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class ScaleTransform(ToFromJSON):
+class ScaleTransform(JSONable):
     """
     An scale transform.
 
@@ -63,12 +63,12 @@ class ScaleTransform(ToFromJSON):
     scale: Sequence[float]
 
     @classmethod
-    def _from_json(cls, json: dict) -> Self:
-        return cls(type="scale", scale=json["scale"])
+    def _from_json(cls, json_: dict) -> Self:
+        return cls(type="scale", scale=json_["scale"])
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class TranslationTransform(ToFromJSON):
+class TranslationTransform(JSONable):
     """
     A translation transform.
 
@@ -86,8 +86,8 @@ class TranslationTransform(ToFromJSON):
     translation: Sequence[float]
 
     @classmethod
-    def _from_json(cls, json: dict) -> Self:
-        return cls(type="translation", translation=json["translation"])
+    def _from_json(cls, json_: dict) -> Self:
+        return cls(type="translation", translation=json_["translation"])
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -104,17 +104,17 @@ class CoordinateTransforms:
     translation: TranslationTransform | None
 
     @classmethod
-    def _from_json(cls, json: list):
-        scale = ScaleTransform._from_json(json[0])
-        if len(json) == 2:
-            translation = TranslationTransform._from_json(json[1])
+    def _from_json(cls, json_: list):
+        scale = ScaleTransform._from_json(json_[0])
+        if len(json_) == 2:
+            translation = TranslationTransform._from_json(json_[1])
         else:
             translation = None
         return cls(scale=scale, translation=translation)
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class Dataset(ToFromJSON):
+class Dataset(JSONable):
     """
     A single dataset.
 
@@ -134,14 +134,14 @@ class Dataset(ToFromJSON):
     coordinateTransformations: CoordinateTransforms
 
     @classmethod
-    def _from_json(cls, json) -> Self:
-        path = json["path"]
-        transforms = CoordinateTransforms._from_json(json["coordinateTransformations"])
+    def _from_json(cls, json_) -> Self:
+        path = json_["path"]
+        transforms = CoordinateTransforms._from_json(json_["coordinateTransformations"])
         return cls(path=path, coordinateTransformations=transforms)
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class MultiscaleMetadata(ToFromJSON):
+class MultiscaleMetadata(JSONable):
     """
     Multiscale metadata.
 
@@ -169,19 +169,19 @@ class MultiscaleMetadata(ToFromJSON):
     type: Any | None = None
 
     @classmethod
-    def _from_json(cls, json: dict) -> Self:
-        axes = tuple(Axis._from_json(v) for v in json["axes"])
-        datasets = [Dataset._from_json(v) for v in json["datasets"]]
-        if json["coordinateTransformations"] is None:
+    def _from_json(cls, json_: dict) -> Self:
+        axes = tuple(Axis._from_json(v) for v in json_["axes"])
+        datasets = [Dataset._from_json(v) for v in json_["datasets"]]
+        if json_["coordinateTransformations"] is None:
             transforms = None
         else:
             transforms = CoordinateTransforms._from_json(
-                json["coordinateTransformations"]
+                json_["coordinateTransformations"]
             )
-        name = json.get("name", None)
-        version = json.get("version", None)
-        metadata = json.get("metadata", None)
-        type_ = json.get("type", None)
+        name = json_.get("name", None)
+        version = json_.get("version", None)
+        metadata = json_.get("metadata", None)
+        type_ = json_.get("type", None)
 
         return cls(
             axes=axes,
@@ -195,7 +195,7 @@ class MultiscaleMetadata(ToFromJSON):
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class MultiscaleMetadatas(ToFromJSON):
+class MultiscaleMetadatas(JSONable):
     """
     A set of multiscale images.
 
@@ -211,8 +211,8 @@ class MultiscaleMetadatas(ToFromJSON):
     multiscales: Sequence[MultiscaleMetadata]
 
     @classmethod
-    def _from_json(cls, json: dict) -> Self:
+    def _from_json(cls, json_: dict) -> Self:
         multiscales = [
-            MultiscaleMetadata._from_json(val) for val in json["multiscales"]
+            MultiscaleMetadata._from_json(val) for val in json_["multiscales"]
         ]
         return cls(multiscales=multiscales)

--- a/tests/data/spec_example_multiscales.json
+++ b/tests/data/spec_example_multiscales.json
@@ -1,0 +1,58 @@
+{
+  "multiscales": [
+    {
+      "version": "0.4",
+      "name": "example",
+      "axes": [
+        { "name": "t", "type": "time", "unit": "millisecond" },
+        { "name": "c", "type": "channel" },
+        { "name": "z", "type": "space", "unit": "micrometer" },
+        { "name": "y", "type": "space", "unit": "micrometer" },
+        { "name": "x", "type": "space", "unit": "micrometer" }
+      ],
+      "datasets": [
+        {
+          "path": "0",
+          "coordinateTransformations": [
+            {
+              "type": "scale",
+              "scale": [1.0, 1.0, 0.5, 0.5, 0.5]
+            }
+          ]
+        },
+        {
+          "path": "1",
+          "coordinateTransformations": [
+            {
+              "type": "scale",
+              "scale": [1.0, 1.0, 1.0, 1.0, 1.0]
+            }
+          ]
+        },
+        {
+          "path": "2",
+          "coordinateTransformations": [
+            {
+              "type": "scale",
+              "scale": [1.0, 1.0, 2.0, 2.0, 2.0]
+            }
+          ]
+        }
+      ],
+      "coordinateTransformations": [
+        {
+          "type": "scale",
+          "scale": [0.1, 1.0, 1.0, 1.0, 1.0]
+        }
+      ],
+      "type": "gaussian",
+      "metadata": {
+        "description": "the fields in metadata depend on the downscaling implementation. Here, the parameters passed to the skimage function are given",
+        "method": "skimage.transform.pyramid_gaussian",
+        "version": "0.16.1",
+        "args": "[true]",
+        "kwargs": { "multichannel": true }
+      }
+    }
+  ]
+}

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,52 +1,65 @@
 import json
 from pathlib import Path
 
-from ome_zarr_models.v04.image import Dataset, MultiscaleMetadata, MultiscaleMetadatas
+from ome_zarr_models.v04.image import (
+    Axis,
+    Dataset,
+    MultiscaleMetadata,
+    MultiscaleMetadatas,
+    ScaleTransform,
+)
 
 
 def test_multiscale_metadata():
     with open(Path(__file__).parent / "data" / "spec_example_multiscales.json") as f:
         json_data = json.load(f)
 
-    metadatas = MultiscaleMetadatas.from_json(json_data)
+    metadatas = MultiscaleMetadatas._from_json(json_data)
     print(metadatas)
     assert metadatas == MultiscaleMetadatas(
         multiscales=[
             MultiscaleMetadata(
-                axes=[
-                    {"name": "t", "type": "time", "unit": "millisecond"},
-                    {"name": "c", "type": "channel"},
-                    {"name": "z", "type": "space", "unit": "micrometer"},
-                    {"name": "y", "type": "space", "unit": "micrometer"},
-                    {"name": "x", "type": "space", "unit": "micrometer"},
-                ],
+                axes=(
+                    Axis(name="t", type="time", unit="millisecond"),
+                    Axis(name="c", type="channel", unit=None),
+                    Axis(name="z", type="space", unit="micrometer"),
+                    Axis(name="y", type="space", unit="micrometer"),
+                    Axis(name="x", type="space", unit="micrometer"),
+                ),
                 datasets=[
                     Dataset(
                         path="0",
-                        coordinateTransformations=[
-                            {"type": "scale", "scale": [1.0, 1.0, 0.5, 0.5, 0.5]}
-                        ],
+                        coordinateTransformations=(
+                            ScaleTransform(
+                                type="scale", scale=[1.0, 1.0, 0.5, 0.5, 0.5]
+                            ),
+                        ),
                     ),
                     Dataset(
                         path="1",
-                        coordinateTransformations=[
-                            {"type": "scale", "scale": [1.0, 1.0, 1.0, 1.0, 1.0]}
-                        ],
+                        coordinateTransformations=(
+                            ScaleTransform(
+                                type="scale", scale=[1.0, 1.0, 1.0, 1.0, 1.0]
+                            ),
+                        ),
                     ),
                     Dataset(
                         path="2",
-                        coordinateTransformations=[
-                            {"type": "scale", "scale": [1.0, 1.0, 2.0, 2.0, 2.0]}
-                        ],
+                        coordinateTransformations=(
+                            ScaleTransform(
+                                type="scale", scale=[1.0, 1.0, 2.0, 2.0, 2.0]
+                            ),
+                        ),
                     ),
-                ],
-                coordinateTransformations=[
-                    {"type": "scale", "scale": [0.1, 1.0, 1.0, 1.0, 1.0]}
                 ],
                 name="example",
                 version="0.4",
                 metadata={
-                    "description": "the fields in metadata depend on the downscaling implementation. Here, the parameters passed to the skimage function are given",
+                    "description": (
+                        "the fields in metadata depend on the downscaling "
+                        "implementation. Here, the parameters passed to "
+                        "the skimage function are given"
+                    ),
                     "method": "skimage.transform.pyramid_gaussian",
                     "version": "0.16.1",
                     "args": "[true]",

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from ome_zarr_models.v04.image import (
     Axis,
+    CoordinateTransforms,
     Dataset,
     MultiscaleMetadata,
     MultiscaleMetadatas,
@@ -29,37 +30,40 @@ def test_multiscale_metadata():
                 datasets=[
                     Dataset(
                         path="0",
-                        coordinateTransformations=(
-                            ScaleTransform(
+                        coordinateTransformations=CoordinateTransforms(
+                            scale=ScaleTransform(
                                 type="scale", scale=[1.0, 1.0, 0.5, 0.5, 0.5]
                             ),
+                            translation=None,
                         ),
                     ),
                     Dataset(
                         path="1",
-                        coordinateTransformations=(
-                            ScaleTransform(
+                        coordinateTransformations=CoordinateTransforms(
+                            scale=ScaleTransform(
                                 type="scale", scale=[1.0, 1.0, 1.0, 1.0, 1.0]
                             ),
+                            translation=None,
                         ),
                     ),
                     Dataset(
                         path="2",
-                        coordinateTransformations=(
-                            ScaleTransform(
+                        coordinateTransformations=CoordinateTransforms(
+                            scale=ScaleTransform(
                                 type="scale", scale=[1.0, 1.0, 2.0, 2.0, 2.0]
                             ),
+                            translation=None,
                         ),
                     ),
                 ],
+                coordinateTransformations=CoordinateTransforms(
+                    scale=ScaleTransform(type="scale", scale=[0.1, 1.0, 1.0, 1.0, 1.0]),
+                    translation=None,
+                ),
                 name="example",
                 version="0.4",
                 metadata={
-                    "description": (
-                        "the fields in metadata depend on the downscaling "
-                        "implementation. Here, the parameters passed to "
-                        "the skimage function are given"
-                    ),
+                    "description": "the fields in metadata depend on the downscaling implementation. Here, the parameters passed to the skimage function are given",
                     "method": "skimage.transform.pyramid_gaussian",
                     "version": "0.16.1",
                     "args": "[true]",

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,2 +1,58 @@
+import json
+from pathlib import Path
+
+from ome_zarr_models.v04.image import Dataset, MultiscaleMetadata, MultiscaleMetadatas
+
+
 def test_multiscale_metadata():
-    pass
+    with open(Path(__file__).parent / "data" / "spec_example_multiscales.json") as f:
+        json_data = json.load(f)
+
+    metadatas = MultiscaleMetadatas.from_json(json_data)
+    print(metadatas)
+    assert metadatas == MultiscaleMetadatas(
+        multiscales=[
+            MultiscaleMetadata(
+                axes=[
+                    {"name": "t", "type": "time", "unit": "millisecond"},
+                    {"name": "c", "type": "channel"},
+                    {"name": "z", "type": "space", "unit": "micrometer"},
+                    {"name": "y", "type": "space", "unit": "micrometer"},
+                    {"name": "x", "type": "space", "unit": "micrometer"},
+                ],
+                datasets=[
+                    Dataset(
+                        path="0",
+                        coordinateTransformations=[
+                            {"type": "scale", "scale": [1.0, 1.0, 0.5, 0.5, 0.5]}
+                        ],
+                    ),
+                    Dataset(
+                        path="1",
+                        coordinateTransformations=[
+                            {"type": "scale", "scale": [1.0, 1.0, 1.0, 1.0, 1.0]}
+                        ],
+                    ),
+                    Dataset(
+                        path="2",
+                        coordinateTransformations=[
+                            {"type": "scale", "scale": [1.0, 1.0, 2.0, 2.0, 2.0]}
+                        ],
+                    ),
+                ],
+                coordinateTransformations=[
+                    {"type": "scale", "scale": [0.1, 1.0, 1.0, 1.0, 1.0]}
+                ],
+                name="example",
+                version="0.4",
+                metadata={
+                    "description": "the fields in metadata depend on the downscaling implementation. Here, the parameters passed to the skimage function are given",
+                    "method": "skimage.transform.pyramid_gaussian",
+                    "version": "0.16.1",
+                    "args": "[true]",
+                    "kwargs": {"multichannel": True},
+                },
+                type="gaussian",
+            )
+        ]
+    )


### PR DESCRIPTION
Adds a abstract base class for objects that can go to/from JSON. I only added the `to_json` so far.

Also adds a basic test against the example metadata given in the v0.4 spec.