### PR TITLE
Implement bioformats2raw structure

### DIFF
--- a/src/ome_zarr_models/base.py
+++ b/src/ome_zarr_models/base.py
@@ -13,3 +13,9 @@ class Base(pydantic.BaseModel):
 
         validate_assignment = True
         extra = "allow"
+        # This allows fields with aliases to be populated by either
+        # their alias or class attribute name
+        #
+        # We use this so we can handle (at least) the "bioformats2raw.version"
+        # key - attributes in Python can't contain a "."
+        populate_by_name = True

--- a/src/ome_zarr_models/v04/__init__.py
+++ b/src/ome_zarr_models/v04/__init__.py
@@ -1,5 +1,4 @@
-from ome_zarr_models.v04.bioformats2raw import BioFormats2RawAttrs
 from ome_zarr_models.v04.hcs import HCS
 from ome_zarr_models.v04.image import Image
 
-__all__ = ["HCS", "Image", "BioFormats2RawAttrs"]
+__all__ = ["HCS", "Image"]

--- a/src/ome_zarr_models/v04/__init__.py
+++ b/src/ome_zarr_models/v04/__init__.py
@@ -1,5 +1,5 @@
-from ome_zarr_models.v04.bioformats2raw import BioFormats2Raw
+from ome_zarr_models.v04.bioformats2raw import BioFormats2RawAttrs
 from ome_zarr_models.v04.hcs import HCS
 from ome_zarr_models.v04.image import Image
 
-__all__ = ["HCS", "Image", "BioFormats2Raw"]
+__all__ = ["HCS", "Image", "BioFormats2RawAttrs"]

--- a/src/ome_zarr_models/v04/__init__.py
+++ b/src/ome_zarr_models/v04/__init__.py
@@ -1,4 +1,5 @@
+from ome_zarr_models.v04.bioformats2raw import BioFormats2Raw
 from ome_zarr_models.v04.hcs import HCS
 from ome_zarr_models.v04.image import Image
 
-__all__ = ["HCS", "Image"]
+__all__ = ["HCS", "Image", "BioFormats2Raw"]

--- a/src/ome_zarr_models/v04/bioformats2raw.py
+++ b/src/ome_zarr_models/v04/bioformats2raw.py
@@ -1,0 +1,16 @@
+from typing import Any, Literal
+
+from pydantic import Field
+
+from ome_zarr_models.base import Base
+from ome_zarr_models.v04.plate import Plate
+
+
+class BioFormats2Raw(Base):
+    """
+    A bioformats2raw zarr group.
+    """
+
+    bioformats2raw_layout = Field(Literal["3"], alias="bioformats2raw.layout")
+    plate: Plate | None = None
+    series: Any | None = None

--- a/src/ome_zarr_models/v04/bioformats2raw.py
+++ b/src/ome_zarr_models/v04/bioformats2raw.py
@@ -11,6 +11,6 @@ class BioFormats2Raw(Base):
     A bioformats2raw zarr group.
     """
 
-    bioformats2raw_layout = Field(Literal["3"], alias="bioformats2raw.layout")
+    bioformats2raw_layout: Literal[3] = Field(..., alias="bioformats2raw.layout")
     plate: Plate | None = None
     series: Any | None = None

--- a/src/ome_zarr_models/v04/bioformats2raw.py
+++ b/src/ome_zarr_models/v04/bioformats2raw.py
@@ -6,7 +6,7 @@ from ome_zarr_models.base import Base
 from ome_zarr_models.v04.plate import Plate
 
 
-class BioFormats2Raw(Base):
+class BioFormats2RawAttrs(Base):
     """
     A bioformats2raw zarr group.
     """

--- a/src/ome_zarr_models/v04/bioformats2raw.py
+++ b/src/ome_zarr_models/v04/bioformats2raw.py
@@ -8,7 +8,7 @@ from ome_zarr_models.v04.plate import Plate
 
 class BioFormats2RawAttrs(Base):
     """
-    A bioformats2raw zarr group.
+    A model of the attributes contained in a bioformats2raw zarr group.
     """
 
     bioformats2raw_layout: Literal[3] = Field(..., alias="bioformats2raw.layout")

--- a/tests/v04/data/bioformats2raw_example.json
+++ b/tests/v04/data/bioformats2raw_example.json
@@ -1,0 +1,30 @@
+{
+  "bioformats2raw.layout": 3,
+  "plate": {
+    "columns": [
+      {
+        "name": "1"
+      }
+    ],
+    "name": "Plate Name 0",
+    "wells": [
+      {
+        "path": "A/1",
+        "rowIndex": 0,
+        "columnIndex": 0
+      }
+    ],
+    "field_count": 1,
+    "rows": [
+      {
+        "name": "A"
+      }
+    ],
+    "acquisitions": [
+      {
+        "id": 0
+      }
+    ],
+    "version": "0.4"
+  }
+}

--- a/tests/v04/test_bioformats2raw.py
+++ b/tests/v04/test_bioformats2raw.py
@@ -1,0 +1,18 @@
+import json
+from pathlib import Path
+
+from ome_zarr_models.v04.bioformats2raw import BioFormats2Raw
+from ome_zarr_models.v04.plate import (
+    AcquisitionInPlate,
+    ColumnInPlate,
+    Plate,
+    RowInPlate,
+    WellInPlate,
+)
+
+
+def test_bioformats2raw_exmaple_json():
+    with open(Path(__file__).parent / "data" / "bioformats2raw_example.json") as f:
+        data = json.load(f)
+
+    assert BioFormats2Raw(**data["bioformats"])

--- a/tests/v04/test_bioformats2raw.py
+++ b/tests/v04/test_bioformats2raw.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 
 from ome_zarr_models.v04.bioformats2raw import BioFormats2Raw
@@ -13,6 +12,22 @@ from ome_zarr_models.v04.plate import (
 
 def test_bioformats2raw_exmaple_json():
     with open(Path(__file__).parent / "data" / "bioformats2raw_example.json") as f:
-        data = json.load(f)
+        model = BioFormats2Raw.model_validate_json(f.read())
 
-    assert BioFormats2Raw(**data["bioformats"])
+    assert model == BioFormats2Raw(
+        bioformats2raw_layout=3,
+        plate=Plate(
+            acquisitions=[
+                AcquisitionInPlate(
+                    id=0, maximumfieldcount=None, name=None, description=None
+                )
+            ],
+            columns=[ColumnInPlate(name="1")],
+            field_count=1,
+            name="Plate Name 0",
+            rows=[RowInPlate(name="A")],
+            version="0.4",
+            wells=[WellInPlate(path="A/1", rowIndex=0, columnIndex=0)],
+        ),
+        series=None,
+    )

--- a/tests/v04/test_bioformats2raw.py
+++ b/tests/v04/test_bioformats2raw.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from ome_zarr_models.v04.bioformats2raw import BioFormats2Raw
+from ome_zarr_models.v04.bioformats2raw import BioFormats2RawAttrs
 from ome_zarr_models.v04.plate import (
     AcquisitionInPlate,
     ColumnInPlate,
@@ -12,9 +12,9 @@ from ome_zarr_models.v04.plate import (
 
 def test_bioformats2raw_exmaple_json():
     with open(Path(__file__).parent / "data" / "bioformats2raw_example.json") as f:
-        model = BioFormats2Raw.model_validate_json(f.read())
+        model = BioFormats2RawAttrs.model_validate_json(f.read())
 
-    assert model == BioFormats2Raw(
+    assert model == BioFormats2RawAttrs(
         bioformats2raw_layout=3,
         plate=Plate(
             acquisitions=[


### PR DESCRIPTION
Implements the parts of https://github.com/BioImageTools/ome-zarr-models-py/issues/31 that do not require parsing XML files (🙈) or zarr groups.

I think the intention of the spec is to have this as another "type" of dataset, alongside HCS and Image, even though it is defined in section 3 (not 2) of the spec. This agrees with the [JSON scheme ipmlementaiton](https://github.com/ome/ngff/blob/main/0.4/schemas/bf2raw.schema) being in it's own file for bioformats2raw.

So I've put it in the `ome_zarr_models.v04` namespace, and I think (for now) we are expecting users to know in advance whether they have a HCS, Image, or BioFormats2Raw dataset? I guess we *could* provide a convenience function to try work out which of these an arbitrary dataset is, but that should go in a separate PR