### PR TITLE
Clean up multiscales

### DIFF
--- a/docs/tutorial.py
+++ b/docs/tutorial.py
@@ -15,12 +15,12 @@ from ome_zarr_models.v04.coordinate_transformations import (
 # OME-zarr dataset:
 
 group = zarr.open("https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr")
-ome_zarr_image = Image(group)
+ome_zarr_image = Image.from_zarr(group)
 pprint(ome_zarr_image)
 
 # This image contains both the zarr group, and a model of the multiscales metadata
 
-multiscales_meta = ome_zarr_image.multiscales
+multiscales_meta = ome_zarr_image.attributes.multiscales
 pprint(multiscales_meta)
 
 # ## Updating models

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,12 +75,14 @@ select = [
     "TID",  # flake8-tidy-imports
 ]
 ignore = [
-    "D401", # First line should be in imperative mood (remove to opt in)
-    "D200", # One line docstring should fit on one line.
-    "D205", # 1 blank line required between summary line and description
-    "D400", # First line should end with a period
-    "D100", # Missing docstring in public module
-    "D104", # Missing docstring in public package
+    "D401",  # First line should be in imperative mood (remove to opt in)
+    "D200",  # One line docstring should fit on one line.
+    "D205",  # 1 blank line required between summary line and description
+    "D400",  # First line should end with a period
+    "D100",  # Missing docstring in public module
+    "D104",  # Missing docstring in public package
+    "TC001", # Move application import `...` into a type-checking block. This messes with nested pydantic models
+
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/ome_zarr_models/v04/image.py
+++ b/src/ome_zarr_models/v04/image.py
@@ -1,48 +1,151 @@
-import zarr
+from __future__ import annotations
 
-from ome_zarr_models.exceptions import ValidationError
-from ome_zarr_models.v04.multiscales import Multiscale, MultiscaleGroupAttrs
+from typing import TYPE_CHECKING, Self
+
+import zarr.errors
+from pydantic import Field, model_validator
+from pydantic_zarr.v2 import ArraySpec, GroupSpec
+
+from ome_zarr_models.base import Base
 from ome_zarr_models.v04.omero import Omero
+from ome_zarr_models.zarr_utils import get_path
 
-__all__ = ["Image"]
+if TYPE_CHECKING:
+    from ome_zarr_models.v04.multiscales import Multiscales
+    from ome_zarr_models.v04.omero import Omero
 
 
-class Image:
+# Image is imported to the `ome_zarr_py.v04` namespace, so not
+# listed here
+__all__ = ["ImageAttrs"]
+
+
+def _check_arrays_compatible(data: Image) -> Image:
     """
-    A object representing OME-zarr image.
-
-    Parameters
-    ----------
-    group :
-        zarr Group which contains the image.
+    Check that all the arrays referenced by the `multiscales` metadata meet the
+    following criteria:
+        - they exist
+        - they are not groups
+        - they have dimensionality consistent with the number of axes defined in the
+          metadata.
     """
+    multimeta = data.attributes.multiscales
+    flat_self = data.to_flat()
 
-    def __init__(self, group: zarr.Group):
-        self._attrs = MultiscaleGroupAttrs(**group.attrs.asdict())
-        if "labels" in group:
-            if not isinstance(group["labels"], zarr.Group):
-                raise ValidationError(
-                    "Expected 'labels' to be a zarr group, but found an array instead."
+    for multiscale in multimeta:
+        multiscale_ndim = len(multiscale.axes)
+        for dataset in multiscale.datasets:
+            try:
+                maybe_arr: ArraySpec | GroupSpec = flat_self[
+                    "/" + dataset.path.lstrip("/")
+                ]
+                if isinstance(maybe_arr, GroupSpec):
+                    msg = f"The node at {dataset.path} is a group, not an array."
+                    raise ValueError(msg)
+                arr_ndim = len(maybe_arr.shape)
+
+                if arr_ndim != multiscale_ndim:
+                    msg = (
+                        f"The multiscale metadata has {multiscale_ndim} axes "
+                        "which does not match the dimensionality of the array "
+                        f"found in this group at {dataset.path} ({arr_ndim}). "
+                        "The number of axes must match the array dimensionality."
+                    )
+
+                    raise ValueError(msg)
+            except KeyError as e:
+                msg = (
+                    f"The multiscale metadata references an array that does not "
+                    f"exist in this group: {dataset.path}"
                 )
+                raise ValueError(msg) from e
+    return data
+
+
+class ImageAttrs(Base):
+    """
+    Model for the metadata of OME-zarr data.
+
+    See https://ngff.openmicroscopy.org/0.4/#image-layout.
+    """
+
+    multiscales: Multiscales = Field(
+        ...,
+        description="The multiscale datasets for this image",
+        min_length=1,
+    )
+    omero: Omero | None = None
+
+
+class Image(GroupSpec[ImageAttrs, ArraySpec | GroupSpec]):
+    """
+    A multiscale zarr group.
+    """
+
+    _check_arrays_compatible = model_validator(mode="after")(_check_arrays_compatible)
+
+    @classmethod
+    def from_zarr(cls, node: zarr.Group) -> Self:
+        """
+        Create an instance of an OME-zarr image from a `zarr.Group`.
+
+        Parameters
+        ----------
+        node: zarr.Group
+            A Zarr group that has valid OME-NGFF image metadata.
+        """
+        # on unlistable storage backends, the members of this group will be {}
+        guess = GroupSpec.from_zarr(node, depth=0)
+
+        try:
+            multi_meta_maybe = guess.attributes["multiscales"]
+        except KeyError as e:
+            store_path = get_path(node.store)
+            msg = (
+                "Failed to find mandatory `multiscales` key in the attributes of the "
+                "Zarr group at "
+                f"{node.store}://{store_path}://{node.path}."
+            )
+            raise KeyError(msg) from e
+
+        multi_meta = ImageAttrs(multiscales=multi_meta_maybe)
+        members_tree_flat = {}
+        for multiscale in multi_meta.multiscales:
+            for dataset in multiscale.datasets:
+                array_path = f"{node.path}/{dataset.path}"
+                try:
+                    array = zarr.open_array(store=node.store, path=array_path, mode="r")
+                    array_spec = ArraySpec.from_zarr(array)
+                except zarr.errors.ArrayNotFoundError as e:
+                    msg = (
+                        f"Expected to find an array at {array_path}, "
+                        "but no array was found there."
+                    )
+                    raise ValueError(msg) from e
+                except zarr.errors.ContainsGroupError as e:
+                    msg = (
+                        f"Expected to find an array at {array_path}, "
+                        "but a group was found there instead."
+                    )
+                    raise ValueError(msg) from e
+                members_tree_flat["/" + dataset.path] = array_spec
+        members_normalized = GroupSpec.from_flat(members_tree_flat)
+
+        guess_inferred_members = guess.model_copy(
+            update={"members": members_normalized.members}
+        )
+        return cls(**guess_inferred_members.model_dump())
 
     @property
-    def multiscales(self) -> list[Multiscale]:
+    def multiscales(self) -> Multiscales:
         """
-        A list of multiscales metadata objects.
+        Multiscales metadata model.
         """
-        return self._attrs.multiscales
+        return self.attributes.multiscales
 
     @property
     def omero(self) -> Omero | None:
         """
-        The omero metadata object.
-
-        Returns `None` if no omero metadata is present in the OME-zarr image.
+        omero metadata model (if present).
         """
-        return self._attrs.omero
-
-    @property
-    def labels(self) -> list[str] | None:
-        """
-        Paths to labels that can be found in the special 'labels' group.
-        """
+        return self.attributes.omero

--- a/src/ome_zarr_models/v04/image.py
+++ b/src/ome_zarr_models/v04/image.py
@@ -1,19 +1,15 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Self
+from typing import Self
 
 import zarr.errors
 from pydantic import Field, model_validator
 from pydantic_zarr.v2 import ArraySpec, GroupSpec
 
 from ome_zarr_models.base import Base
+from ome_zarr_models.v04.multiscales import Multiscales
 from ome_zarr_models.v04.omero import Omero
 from ome_zarr_models.zarr_utils import get_path
-
-if TYPE_CHECKING:
-    from ome_zarr_models.v04.multiscales import Multiscales
-    from ome_zarr_models.v04.omero import Omero
-
 
 # Image is imported to the `ome_zarr_py.v04` namespace, so not
 # listed here

--- a/src/ome_zarr_models/v04/image_label.py
+++ b/src/ome_zarr_models/v04/image_label.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Annotated, Literal
 from pydantic import AfterValidator, Field, model_validator
 
 from ome_zarr_models.base import Base
-from ome_zarr_models.v04.multiscales import MultiscaleGroupAttrs
+from ome_zarr_models.v04.image import ImageAttrs
 
 if TYPE_CHECKING:
     from collections.abc import Hashable, Iterable
@@ -126,7 +126,7 @@ class ImageLabel(Base):
         return _parse_imagelabel(self)
 
 
-class GroupAttrs(MultiscaleGroupAttrs):
+class GroupAttrs(ImageAttrs):
     """
     Attributes for a Zarr group that contains `image-label` metadata.
     Inherits from `v04.multiscales.MultiscaleAttrs`.

--- a/src/ome_zarr_models/v04/multiscales.py
+++ b/src/ome_zarr_models/v04/multiscales.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 from collections import Counter
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Annotated, Any, get_args
 
-import zarr
 from pydantic import AfterValidator, Field, model_validator
-from pydantic_zarr.v2 import ArraySpec, GroupSpec
 
 from ome_zarr_models.base import Base
 from ome_zarr_models.utils import duplicates
@@ -17,21 +16,20 @@ from ome_zarr_models.v04.coordinate_transformations import (
     _build_transforms,
     _ndim,
 )
-from ome_zarr_models.v04.omero import Omero  # noqa: TC001
-from ome_zarr_models.zarr_utils import get_path
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
 
-__all__ = ["VALID_NDIM", "Dataset", "Multiscale", "MultiscaleGroup"]
+__all__ = ["Dataset", "Multiscale", "Multiscales"]
 
 VALID_NDIM = (2, 3, 4, 5)
+ValidTransform = tuple[ScaleTransform] | tuple[ScaleTransform, TranslationTransform]
 
 
 def _ensure_transform_dimensionality(
-    transforms: tuple[ScaleTransform] | tuple[ScaleTransform, TranslationTransform],
-) -> tuple[ScaleTransform] | tuple[ScaleTransform, TranslationTransform]:
+    transforms: ValidTransform,
+) -> ValidTransform:
     """
     Ensures that the elements in the input sequence define transformations with
     identical dimensionality. If any of the transforms are defined with a path
@@ -51,8 +49,8 @@ def _ensure_transform_dimensionality(
 
 
 def _ensure_scale_translation(
-    transforms: tuple[ScaleTransform] | tuple[ScaleTransform, TranslationTransform],
-) -> tuple[ScaleTransform] | tuple[ScaleTransform, TranslationTransform]:
+    transforms: ValidTransform,
+) -> ValidTransform:
     """
     Ensures that
     - there are only 1 or 2 transforms.
@@ -95,7 +93,7 @@ def _ensure_axis_length(axes: Axes) -> Axes:
     return axes
 
 
-def _ensure_axis_names(axes: Axes) -> Axes:
+def _ensure_unique_axis_names(axes: Axes) -> Axes:
     """
     Ensures that the names of the axes are unique.
     """
@@ -162,10 +160,11 @@ class Dataset(Base):
     """
 
     # TODO: validate that path resolves to an actual zarr array
+    # TODO: can we validate that the paths must be ordered from highest resolution to
+    # smallest using scale metadata?
     path: str
-    # TODO: validate that transforms are consistent w.r.t dimensionality
     coordinateTransformations: Annotated[
-        tuple[ScaleTransform] | tuple[ScaleTransform, TranslationTransform],
+        ValidTransform,
         AfterValidator(_ensure_scale_translation),
         AfterValidator(_ensure_transform_dimensionality),
     ]
@@ -181,6 +180,9 @@ class Dataset(Base):
                 scale=scale, translation=translation
             ),
         )
+
+
+Datasets = Sequence[Dataset]
 
 
 def _ensure_top_transforms_dimensionality(data: Multiscale) -> Multiscale:
@@ -248,17 +250,15 @@ class Multiscale(Base):
     See https://ngff.openmicroscopy.org/0.4/#multiscale-md.
     """
 
-    datasets: tuple[Dataset, ...] = Field(..., min_length=1)
-    version: Any | None = None
     axes: Annotated[
         Axes,
         AfterValidator(_ensure_axis_length),
-        AfterValidator(_ensure_axis_names),
+        AfterValidator(_ensure_unique_axis_names),
         AfterValidator(_ensure_axis_types),
     ]
-    coordinateTransformations: (
-        tuple[ScaleTransform] | tuple[ScaleTransform, TranslationTransform] | None
-    ) = None
+    datasets: Datasets = Field(..., min_length=1)
+    version: Any | None = None
+    coordinateTransformations: ValidTransform | None = None
     metadata: Any = None
     name: Any | None = None
     type: Any = None
@@ -283,126 +283,4 @@ class Multiscale(Base):
     )
 
 
-class MultiscaleGroupAttrs(Base):
-    """
-    Model for the metadata of a NGFF image.
-
-    See https://ngff.openmicroscopy.org/0.4/#image-layout.
-    """
-
-    multiscales: tuple[Multiscale, ...] = Field(
-        ...,
-        description="The multiscale datasets for this image",
-        min_length=1,
-    )
-    omero: Omero | None = None
-
-
-def _check_arrays_compatible(data: MultiscaleGroup) -> MultiscaleGroup:
-    """
-    Check that all the arrays referenced by the `multiscales` metadata meet the
-    following criteria:
-        - they exist
-        - they are not groups
-        - they have dimensionality consistent with the number of axes defined in the
-          metadata.
-    """
-    multimeta = data.attributes.multiscales
-    flat_self = data.to_flat()
-
-    for multiscale in multimeta:
-        multiscale_ndim = len(multiscale.axes)
-        for dataset in multiscale.datasets:
-            try:
-                maybe_arr: ArraySpec | GroupSpec = flat_self[
-                    "/" + dataset.path.lstrip("/")
-                ]
-                if isinstance(maybe_arr, GroupSpec):
-                    msg = f"The node at {dataset.path} is a group, not an array."
-                    raise ValueError(msg)
-                arr_ndim = len(maybe_arr.shape)
-
-                if arr_ndim != multiscale_ndim:
-                    msg = (
-                        f"The multiscale metadata has {multiscale_ndim} axes "
-                        "which does not match the dimensionality of the array "
-                        f"found in this group at {dataset.path} ({arr_ndim}). "
-                        "The number of axes must match the array dimensionality."
-                    )
-
-                    raise ValueError(msg)
-            except KeyError as e:
-                msg = (
-                    f"The multiscale metadata references an array that does not "
-                    f"exist in this group: {dataset.path}"
-                )
-                raise ValueError(msg) from e
-    return data
-
-
-class MultiscaleGroup(GroupSpec[MultiscaleGroupAttrs, ArraySpec | GroupSpec]):
-    """
-    A multiscale group.
-    """
-
-    _check_arrays_compatible = model_validator(mode="after")(_check_arrays_compatible)
-
-    @classmethod
-    def from_zarr(cls, node: zarr.Group) -> MultiscaleGroup:
-        """
-        Create an instance of `Group` from a `node`, a `zarr.Group`.
-
-        This method discovers Zarr arrays in the hierarchy rooted at `node` by
-        inspecting the OME-NGFF multiscales metadata.
-
-        Parameters
-        ----------
-        node: zarr.Group
-            A Zarr group that has valid OME-NGFF multiscale metadata.
-
-        Returns
-        -------
-        Group
-            A model of the Zarr group.
-        """
-        # on unlistable storage backends, the members of this group will be {}
-        guess = GroupSpec.from_zarr(node, depth=0)
-
-        try:
-            multi_meta_maybe = guess.attributes["multiscales"]
-        except KeyError as e:
-            store_path = get_path(node.store)
-            msg = (
-                "Failed to find mandatory `multiscales` key in the attributes of the "
-                "Zarr group at "
-                f"{node.store}://{store_path}://{node.path}."
-            )
-            raise KeyError(msg) from e
-
-        multi_meta = MultiscaleGroupAttrs(multiscales=multi_meta_maybe)
-        members_tree_flat = {}
-        for multiscale in multi_meta.multiscales:
-            for dataset in multiscale.datasets:
-                array_path = f"{node.path}/{dataset.path}"
-                try:
-                    array = zarr.open_array(store=node.store, path=array_path, mode="r")
-                    array_spec = ArraySpec.from_zarr(array)
-                except zarr.errors.ArrayNotFoundError as e:
-                    msg = (
-                        f"Expected to find an array at {array_path}, "
-                        "but no array was found there."
-                    )
-                    raise ValueError(msg) from e
-                except zarr.errors.ContainsGroupError as e:
-                    msg = (
-                        f"Expected to find an array at {array_path}, "
-                        "but a group was found there instead."
-                    )
-                    raise ValueError(msg) from e
-                members_tree_flat["/" + dataset.path] = array_spec
-        members_normalized = GroupSpec.from_flat(members_tree_flat)
-
-        guess_inferred_members = guess.model_copy(
-            update={"members": members_normalized.members}
-        )
-        return cls(**guess_inferred_members.model_dump())
+Multiscales = Sequence[Multiscale]

--- a/tests/v04/conftest.py
+++ b/tests/v04/conftest.py
@@ -9,11 +9,10 @@ from pydantic_zarr.v2 import ArraySpec, GroupSpec
 from zarr.util import guess_chunks
 
 from ome_zarr_models.v04.axes import Axis
+from ome_zarr_models.v04.image import Image, ImageAttrs
 from ome_zarr_models.v04.multiscales import (
     Dataset,
     Multiscale,
-    MultiscaleGroup,
-    MultiscaleGroupAttrs,
 )
 
 
@@ -63,13 +62,13 @@ def from_arrays(
     compressor: Codec | Literal["auto"] = "auto",
     fill_value: Any = 0,
     order: Literal["C", "F", "auto"] = "auto",
-) -> MultiscaleGroup:
+) -> Image:
     """
-    Create a `MultiscaleGroup` from a sequence of multiscale arrays
+    Create a `Image` from a sequence of multiscale arrays
     and spatial metadata.
 
     The arrays are used as templates for corresponding `ArraySpec` instances,
-    which model the Zarr arrays that would be created if the `MultiscaleGroup`
+    which model the Zarr arrays that would be created if the `Image`
     was stored.
 
     Parameters
@@ -143,9 +142,9 @@ def from_arrays(
         ),
         coordinateTransformations=None,
     )
-    return MultiscaleGroup(
+    return Image(
         members=GroupSpec.from_flat(members_flat).members,
-        attributes=MultiscaleGroupAttrs(multiscales=(multimeta,)),
+        attributes=ImageAttrs(multiscales=(multimeta,)),
     )
 
 
@@ -163,12 +162,12 @@ def from_array_props(
     compressor: Codec | Literal["auto"] = "auto",
     fill_value: Any = 0,
     order: Literal["C", "F"] = "C",
-) -> MultiscaleGroup:
+) -> Image:
     """
-    Create a `MultiscaleGroup` from a dtype and a sequence of shapes.
+    Create a `Image` from a dtype and a sequence of shapes.
 
     The dtype and shapes are used to parametrize `ArraySpec` instances which model the
-    Zarr arrays that would be created if the `MultiscaleGroup` was stored.
+    Zarr arrays that would be created if the `Image` was stored.
 
     Parameters
     ----------
@@ -244,7 +243,7 @@ def from_array_props(
         ),
         coordinateTransformations=None,
     )
-    return MultiscaleGroup(
+    return Image(
         members=GroupSpec.from_flat(members_flat).members,
-        attributes=MultiscaleGroupAttrs(multiscales=(multimeta,)),
+        attributes=ImageAttrs(multiscales=(multimeta,)),
     )


### PR DESCRIPTION
Some work towards https://github.com/BioImageTools/ome-zarr-models-py/issues/33.

I've tried to clean this up so that `multiscales.py` just contains the multiscales data model. Even if that part of the spec contains some validations we need zarr arrays for, for clarity I think it's best to do these elsewhere. I then relaised that my `Image` class was intended to be the same as @d-v-b's `MultiscaleGroup` group, so I deleted `Image` and renamed `MultiscaleGroup` to image. I think this makes sense, but I'm a bit unsure so folks should definitely feel free to disagree/suggest alternatives.

There's a few minor additions of types where they're used > once too.