### PR TITLE
Clean up transformations a bit

### DIFF
--- a/docs/tutorial.py
+++ b/docs/tutorial.py
@@ -6,7 +6,7 @@ from rich.pretty import pprint
 
 from ome_zarr_models.v04 import Image
 from ome_zarr_models.v04.coordinate_transformations import (
-    VectorTranslation,
+    Translation,
 )
 
 # ## Creating models
@@ -37,7 +37,7 @@ pprint(multiscales_meta)
 # scale, or a scale then translation (strictly in that order). So if we try and make a
 # transformation just a translation, it will raise an error.
 
-multiscales_meta[0].datasets[0].coordinateTransformations = VectorTranslation(
+multiscales_meta[0].datasets[0].coordinateTransformations = Translation(
     type="translation", translation=[1, 2, 3]
 )
 

--- a/src/ome_zarr_models/v04/coordinate_transformations.py
+++ b/src/ome_zarr_models/v04/coordinate_transformations.py
@@ -26,7 +26,15 @@ __all__ = [
 ]
 
 
-class Identity(Base):
+class Transformation(Base):
+    """
+    Base transformation class.
+    """
+
+    type: Literal["identity", "translation", "scale"]
+
+
+class Identity(Transformation):
     """
     Identity transformation.
 
@@ -39,7 +47,7 @@ class Identity(Base):
     type: Literal["identity"]
 
 
-class VectorScale(Base):
+class VectorScale(Transformation):
     """
     Scale transformation parametrized by a vector of numbers.
     """
@@ -62,7 +70,7 @@ class VectorScale(Base):
         return len(self.scale)
 
 
-class PathScale(Base):
+class PathScale(Transformation):
     """
     Scale transformation parametrized by a path.
     """
@@ -71,7 +79,7 @@ class PathScale(Base):
     path: str
 
 
-class VectorTranslation(Base):
+class VectorTranslation(Transformation):
     """
     Translation transformation parametrized by a vector of numbers.
     """
@@ -94,7 +102,7 @@ class VectorTranslation(Base):
         return len(self.translation)
 
 
-class PathTranslation(Base):
+class PathTranslation(Transformation):
     """
     Translation transformation parametrized by a path.
     """

--- a/src/ome_zarr_models/v04/multiscales.py
+++ b/src/ome_zarr_models/v04/multiscales.py
@@ -14,17 +14,15 @@ from ome_zarr_models.base import Base
 from ome_zarr_models.utils import duplicates
 from ome_zarr_models.v04.axes import Axes, AxisType
 from ome_zarr_models.v04.coordinate_transformations import (
-    ScaleTransform,
-    TranslationTransform,
-    VectorTransform,
+    Scale,
+    Translation,
     _build_transforms,
-    _ndim,
 )
 
 __all__ = ["Dataset", "Multiscale", "Multiscales"]
 
 VALID_NDIM = (2, 3, 4, 5)
-ValidTransform = tuple[ScaleTransform] | tuple[ScaleTransform, TranslationTransform]
+ValidTransform = tuple[Scale] | tuple[Scale, Translation]
 
 
 def _ensure_transform_dimensionality(
@@ -36,8 +34,8 @@ def _ensure_transform_dimensionality(
     instead of concrete values, then no validation will be performed and the
     transforms will be returned as-is.
     """
-    vector_transforms = filter(lambda v: isinstance(v, VectorTransform), transforms)
-    ndims = tuple(map(_ndim, vector_transforms))
+    vector_transforms = [t for t in transforms if not t.is_path_transform]
+    ndims = [t.ndim for t in vector_transforms]
     ndims_set = set(ndims)
     if len(ndims_set) > 1:
         msg = (

--- a/tests/v04/test_multiscales.py
+++ b/tests/v04/test_multiscales.py
@@ -11,8 +11,8 @@ from tests.v04.conftest import from_array_props, from_arrays
 
 from ome_zarr_models.v04.axes import Axis
 from ome_zarr_models.v04.coordinate_transformations import (
-    VectorScale,
-    VectorTranslation,
+    Scale,
+    Translation,
     _build_transforms,
 )
 from ome_zarr_models.v04.image import Image, ImageAttrs
@@ -127,11 +127,11 @@ def test_transform_invalid_ndims(
     "transforms",
     [
         (
-            VectorScale.build((1, 1, 1)),
-            VectorTranslation.build((1, 1, 1)),
-            VectorTranslation.build((1, 1, 1)),
+            Scale.build((1, 1, 1)),
+            Translation.build((1, 1, 1)),
+            Translation.build((1, 1, 1)),
         ),
-        (VectorScale.build((1, 1, 1)),) * 5,
+        (Scale.build((1, 1, 1)),) * 5,
     ],
 )
 def test_transform_invalid_length(
@@ -146,10 +146,10 @@ def test_transform_invalid_length(
 @pytest.mark.parametrize(
     "transforms",
     [
-        (VectorTranslation.build((1, 1, 1)),) * 2,
+        (Translation.build((1, 1, 1)), Translation.build((1, 1, 1))),
         (
-            VectorTranslation.build((1, 1, 1)),
-            VectorScale.build((1, 1, 1)),
+            Translation.build((1, 1, 1)),
+            Scale.build((1, 1, 1)),
         ),
     ],
 )
@@ -158,7 +158,7 @@ def test_transform_invalid_first_element(
 ) -> None:
     with pytest.raises(
         ValidationError,
-        match="Input should be a valid dictionary or instance of VectorScale",
+        match="Input should be a valid dictionary or instance of Scale",
     ):
         Dataset(path="foo", coordinateTransformations=transforms)
 
@@ -167,17 +167,17 @@ def test_transform_invalid_first_element(
     "transforms",
     (
         (
-            VectorScale.build((1, 1, 1)),
-            VectorScale.build((1, 1, 1)),
+            Scale.build((1, 1, 1)),
+            Scale.build((1, 1, 1)),
         ),
     ),
 )
 def test_transform_invalid_second_element(
-    transforms: tuple[VectorScale, VectorScale],
+    transforms: tuple[Scale, Scale],
 ) -> None:
     with pytest.raises(
         ValidationError,
-        match="Input should be a valid dictionary or instance of VectorTranslation",
+        match="Input should be a valid dictionary or instance of Translation",
     ):
         Dataset(path="foo", coordinateTransformations=transforms)
 

--- a/tests/v04/test_omero.py
+++ b/tests/v04/test_omero.py
@@ -1,10 +1,14 @@
 import json
+import re
 from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
 
 from ome_zarr_models.v04.omero import Channel, Omero, Window
 
 
-def test_load_example_json():
+def test_load_example_json() -> None:
     with open(Path(__file__).parent / "data" / "omero_example.json") as f:
         data = json.load(f)
 
@@ -25,3 +29,17 @@ def test_load_example_json():
         version="0.4",
         rdefs={"defaultT": 0, "defaultZ": 118, "model": "color"},
     )
+
+
+def test_bad_colour() -> None:
+    # Check that a non-hex colour raises a validation error
+    expected_msg = re.escape("String should match pattern '[0-9a-fA-F]{6}'")
+    with pytest.raises(ValidationError, match=expected_msg):
+        Omero(
+            channels=[
+                Channel(
+                    color="0000FP",
+                    window=Window(max=65535.0, min=0.0, start=0.0, end=1500.0),
+                )
+            ],
+        )


### PR DESCRIPTION
This cleans up the Transformations objects a bit so that there's now a single `Scale` and `Translation` class, and the `scale` or `translation` key in each of them can take either a path or a vector. I think this makes everything a bit clearer by not having lots of different classes, and makes checking for `ndim` a bit cleaner too.

This also finishes off the coordinateTransformations part of the spec, so fixes https://github.com/BioImageTools/ome-zarr-models-py/issues/32.

