### PR TITLE
Use prettier instead of mdformat

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-# Maintain dependencies for GitHub Actions
+  # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ci:
   autofix_prs: false
-  autoupdate_commit_msg: 'Update pre-commit hooks'
+  autoupdate_commit_msg: "Update pre-commit hooks"
 
 repos:
   - repo: https://github.com/abravalheri/validate-pyproject
@@ -25,25 +25,25 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
-    -   id: trailing-whitespace
+      - id: trailing-whitespace
 
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.19.1
     hooks:
-    -   id: blacken-docs
+      - id: blacken-docs
         additional_dependencies:
-        - black==22.12.0
+          - black==22.12.0
 
-  - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.21
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: "v3.4.2"
     hooks:
-    - id: mdformat
+      - id: prettier
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.14.0
     hooks:
-    -   id: mypy
+      - id: mypy
         additional_dependencies:
-        - pydantic
-        - pytest
-        - pydantic-zarr
+          - pydantic
+          - pytest
+          - pydantic-zarr

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 {
-    "python.testing.pytestArgs": [
-        "tests"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+  "python.testing.pytestArgs": ["tests"],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
 }

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -11,10 +11,10 @@ A listing of the group objects and associated metadata objects is given below fo
 
 ### v04
 
-| OME-Zarr group objects | Metadata attributes |
+| OME-Zarr group objects                                     | Metadata attributes                                                  |
 | ---------------------------------------------------------- | -------------------------------------------------------------------- |
-| \[`HCS`\][ome_zarr_models.v04.hcs.HCS] | \[`HCSAttrs`\][ome_zarr_models.v04.hcs.HCSAttrs] |
-| \[`Image`\][ome_zarr_models.v04.image.Image] | \[`ImageAttrs`\][ome_zarr_models.v04.image.ImageAttrs] |
-| \[`Labels`\][ome_zarr_models.v04.labels.Labels] | \[`LabelsAttrs`\][ome_zarr_models.v04.labels.LabelsAttrs] |
-| \[`ImageLabel`\][ome_zarr_models.v04.image_label.ImageLabel] | \[`ImageLabelAttrs`\][ome_zarr_models.v04.image_label.ImageLabelAttrs] |
-| \[`Well`\][ome_zarr_models.v04.well.Well] | \[`WellAttrs`\][ome_zarr_models.v04.well.WellAttrs] |
+| [`HCS`][ome_zarr_models.v04.hcs.HCS]                       | [`HCSAttrs`][ome_zarr_models.v04.hcs.HCSAttrs]                       |
+| [`Image`][ome_zarr_models.v04.image.Image]                 | [`ImageAttrs`][ome_zarr_models.v04.image.ImageAttrs]                 |
+| [`Labels`][ome_zarr_models.v04.labels.Labels]              | [`LabelsAttrs`][ome_zarr_models.v04.labels.LabelsAttrs]              |
+| [`ImageLabel`][ome_zarr_models.v04.image_label.ImageLabel] | [`ImageLabelAttrs`][ome_zarr_models.v04.image_label.ImageLabelAttrs] |
+| [`Well`][ome_zarr_models.v04.well.Well]                    | [`WellAttrs`][ome_zarr_models.v04.well.WellAttrs]                    |


### PR DESCRIPTION
mdformat was breaking links in a table, and prettier also gives us nice YAML and JSON formatting as a bonus.